### PR TITLE
simplify working with interactive plots

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,98 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+BreakBeforeInheritanceComma: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '$'
+IndentCaseLabels: false
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+ReflowComments:  true
+SortIncludes:    false
+SpaceAfterCStyleCast: true
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: false
+SpaceBeforeParens: Never
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: false
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 - osx
 before_install:
 - if [ $TRAVIS_OS_NAME = linux ]; then sudo apt-get install r-base; fi
-- if [ $TRAVIS_OS_NAME = osx ]; then brew update;brew install r; fi
+- if [ $TRAVIS_OS_NAME = osx ]; then brew update;brew install gcc; brew link --overwrite gcc; brew install r; fi
 script:
 - make
 - echo "Preparing version $TRAVIS_BRANCH-$TRAVIS_COMMIT"

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,13 @@ TGT=$(addsuffix /embedr.so,$(QARCH))
 
 all:
 	mkdir -p $(QARCH)
-	R CMD gcc -o $(TGT) $(CFLAGS) $(R_INCLUDES) $(SRC) $(LIBS) -std=c11 -Wall
+	R CMD gcc -o $(TGT) $(CFLAGS) $(R_INCLUDES) $(SRC) $(LIBS) -Wall
 
 install:
 	install $(TGT) $(Q)
 
 clean:
 	rm -rf $(TGT)
+
+fmt:
+	clang-format -style=file embedr.c src/rserver.c src/qserver.c src/common.c -i

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ TGT=$(addsuffix /embedr.so,$(QARCH))
 
 all:
 	mkdir -p $(QARCH)
-	R CMD gcc -o $(TGT) $(CFLAGS) $(R_INCLUDES) $(SRC) $(LIBS) 
+	R CMD gcc -o $(TGT) $(CFLAGS) $(R_INCLUDES) $(SRC) $(LIBS) -std=c11 -Wall
 
 install:
 	install $(TGT) $(Q)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ For example, a script to load q might be:
   rlwrap q "$@"
 ```
 
+The library has four main methods:
+
+- `Ropen`: Initialise embedded R. Optional to call. Allows to set verbose mode as `Ropen 1`.
+- `Rcmd`: run an R command, do not return a result
+- `Rget`: run an R command, return the result to q
+- `Rset`: set a variable in the R memory space
+
 ### Interactive plotting
 If using interactive plotting, you have to take care of some extras.
 1. Call `Reventloop[]`. Note that this will override timer and `.z.ts`. It will give R library some time to process graphics event. macOS and Windows only.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,17 @@ environment     | action
 ----------------|---------------------------------------------------------------------------------------
 Linux           | `tar xzvf embedr_linux-v*.tar.gz -C $QHOME --strip 1`
 macOS           | `tar xzvf embedr_osx-v*.tar.gz -C $QHOME --strip 1`
-Windows         | Open the archive and copy content of the `embedr` folder (`embedr\*`) to `%QHOME%` or `c:\q`
+Windows         | Open the archive and copy content of the `embedr` folder (`embedr\*`) to `%QHOME%` or `c:\q`<br/>Copy R_HOME/x64/*.dll or R_HOME/i386/*.dll to QHOME/w64 or QHOME/w32 respectively. 
 
 
 ## Calling R
 
 When calling R, you need to set `R_HOME`. Required are:
 ```
-  R_HOME               - R home path      (e.g. /usr/lib/R)
+# Linux/macOS
+export R_HOME=`R RHOME`
+# Windows
+for /f "delims=" %a in ('R RHOME') do @set R_HOME=%a
 ```
 For example, a script to load q might be:
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,6 @@ export R_HOME=`R RHOME`
 # Windows
 for /f "delims=" %a in ('R RHOME') do @set R_HOME=%a
 ```
-For example, a script to load q might be:
-
-```
-  #!/bin/bash
-  export R_HOME=`R RHOME`
-  rlwrap q "$@"
-```
 
 The library has four main methods:
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ The library has four main methods:
 - `Rset`: set a variable in the R memory space
 
 ### Interactive plotting
-If using interactive plotting, you have to take care of some extras.
-1. Call `Reventloop[]`. Note that this will override timer and `.z.ts`. It will give R library some time to process graphics event. macOS and Windows only.
-2. To plot with `lattice` and/or `ggplot2` you will need to call `print` on chart object. 
+If using interactive plotting with `lattice` and/or `ggplot2` you will need to call `print` on chart object. 
 
 ## Examples
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
 
 build_script:
 - cmd: mkdir w%BITS%
-- cmd: R.exe CMD SHLIB -o w%BITS%/embedr.dll embedr.c src/w%BITS%/q.a
+- cmd: R.exe CMD SHLIB -o w%BITS%/embedr.dll embedr.c src/w%BITS%/q.a -lws2_32
 
 after_build:
 - cmd: mkdir embedr

--- a/embedr.c
+++ b/embedr.c
@@ -13,6 +13,7 @@
 #define closesocket(x) close(x)
 #endif
 #include <R_ext/Parse.h>
+#include "src/socketpair.c"
 #define KXVER 3
 #include "src/k.h"
 

--- a/embedr.c
+++ b/embedr.c
@@ -10,12 +10,12 @@
 #ifndef WIN32
 #include <Rinterface.h>
 #include <pthread.h>
-#include <sys/socket.h>
 #include <sys/types.h>
+#include <sys/socket.h>
 //#include <unistd.h>
 #else
+#include <windows.h>
 #include <process.h> 
-#define closesocket(x) close(x)
 #endif
 
 #include <R_ext/Parse.h>

--- a/embedr.c
+++ b/embedr.c
@@ -14,6 +14,7 @@
 #include <sys/types.h>
 //#include <unistd.h>
 #else
+#include <process.h> 
 #define closesocket(x) close(x)
 #endif
 

--- a/embedr.c
+++ b/embedr.c
@@ -6,14 +6,20 @@
 #include <R.h>
 #include <Rdefines.h>
 #include <Rembedded.h>
+#include <time.h>
 #ifndef WIN32
 #include <Rinterface.h>
-#endif
-#ifdef WIN32
+#include <pthread.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+//#include <unistd.h>
+#else
 #define closesocket(x) close(x)
 #endif
+
 #include <R_ext/Parse.h>
 #include "src/socketpair.c"
+
 #define KXVER 3
 #include "src/k.h"
 

--- a/examples/pcd.q
+++ b/examples/pcd.q
@@ -1,7 +1,5 @@
 //\l rinit.q
 
-Reventloop[];
-
 basedir:`:.^hsym `$last -2 _ get{}
 datafile:` sv first[` vs basedir],`pcd2014v1.csv
 if[()~key datafile;'"Data file not found. See README.md"]

--- a/rinit.q
+++ b/rinit.q
@@ -5,7 +5,6 @@ Ropen:`embedr 2:(`ropen;1)
 Rcmd0:`embedr 2:(`rcmd;1)
 Rget0:`embedr 2:(`rget;1)
 Rset0:`embedr 2:(`rset;2)
-Revents0:`embedr 2:(`revents;1)
 Rcmd:{Rcmd0 x}
 Rget:{r:Rget0 x;Rconv r}
 Rset:{Rset0[x;y]}
@@ -32,4 +31,3 @@ Rinstall:{[pkg]
   }
 Roff:{Rcmd "dev.off()"}
 Rnew:{Rcmd "dev.new(noRStudioGD=TRUE)"}
-Reventloop:{.z.ts:Revents0;system"t 1000";}

--- a/rtest.q
+++ b/rtest.q
@@ -1,7 +1,7 @@
 / test R server for Q
 \l rinit.q
 
-Ropen 0
+Ropen 1   // set verbose mode
 
 Rcmd "a=array(1:24,c(2,3,4))"
 Rget "dim(a)"

--- a/src/rserver.c
+++ b/src/rserver.c
@@ -375,7 +375,7 @@ K ropen(K x)
 {
 	if (ROPEN >= 0) return ki(ROPEN);
 	int s,mode=0;	char *argv[] = {"R","--slave"};
-	if (x && -KI ==x->t) mode=x->i!=0;
+	if (x && (-KI ==x->t || -KJ ==x->t)) mode=(x->t==-KI?x->i:x->j)!=0;
 	if (mode) argv[1] = "--verbose";
 	int argc = sizeof(argv)/sizeof(argv[0]);
 	s=Rf_initEmbeddedR(argc, argv);
@@ -395,7 +395,7 @@ static char* ParseError[5]={"null","ok","incomplete","error","eof"};
 
 K rexec(int type,K x)
 {
-	if (ROPEN == 0) ropen(ki(0));
+	if (ROPEN < 0) ropen(NULL);
 	SEXP e, p, r, xp;
 	char rerr[256];extern char	R_ParseErrorMsg[256];
 	int error;
@@ -423,7 +423,7 @@ K rexec(int type,K x)
 }
 
 K rset(K x,K y) {
-	if (ROPEN == 0) ropen(ki(0));
+	if (ROPEN < 0) ropen(NULL);
 	ParseStatus status;
 	SEXP txt, sym, val;
 	char rerr[256];extern char	R_ParseErrorMsg[256];

--- a/src/rserver.c
+++ b/src/rserver.c
@@ -285,10 +285,10 @@ static char * getkstring(K x)
 	case -KC :
 		s = calloc(2,1); s[0] = xg; break;
 	case KC :
-		s = calloc(1+xn,1); memcpy(s, xG, xn); break;
-	case -KS :
+		s = calloc(1+xn,1); memmove(s, xG, xn); break;
+	case -KS : // TODO: xs is already 0 terminated and fixed. can just return xs
 		len = 1+strlen(xs);
-		s = calloc(len,1); memcpy(s, xs, len); break;
+		s = calloc(len,1); memmove(s, xs, len); break;
 	default : krr("invalid name");
 	}
 	return s;

--- a/src/rserver.c
+++ b/src/rserver.c
@@ -404,7 +404,7 @@ K ropen(K x)
   pingthread= &t;
  	#else
   if(_beginthreadex(0,0,pingmain,NULL,0,0)==-1)
-   	R krr("poller_thread")
+   	R krr("poller_thread");
 	#endif
 	ROPEN=mode;
 	return ki(ROPEN);

--- a/src/rserver.c
+++ b/src/rserver.c
@@ -400,11 +400,12 @@ K ropen(K x)
 	#ifndef WIN32
  	pthread_t t;
   if(pthread_create(&t, NULL, pingmain, NULL))
-     perror("poller_thread");
-   pingthread= &t;
- #else
-   _beginthread(pingmain, 0, NULL);
- #endif
+     R krr("poller_thread");
+  pingthread= &t;
+ 	#else
+  if(_beginthreadex(0,0,pingmain,NULL,0,0)==-1)
+   	R krr("poller_thread")
+	#endif
 	ROPEN=mode;
 	return ki(ROPEN);
 }

--- a/src/socketpair.c
+++ b/src/socketpair.c
@@ -1,0 +1,112 @@
+/* socketpair.c
+ * Copyright 2007 by Nathan C. Myers <ncm@cantrip.org>; some rights reserved.
+ * This code is Free Software.  It may be copied freely, in original or 
+ * modified form, subject only to the restrictions that (1) the author is
+ * relieved from all responsibilities for any use for any purpose, and (2)
+ * this copyright notice must be retained, unchanged, in its entirety.  If
+ * for any reason the author might be held responsible for any consequences
+ * of copying or use, license is withheld.  
+ */
+
+/* Changes:
+ * 2010-02-25:
+ *   set SO_REUSEADDR option to avoid leaking some windows resource.
+ *   Windows System Error 10049, "Event ID 4226 TCP/IP has reached 
+ *   the security limit imposed on the number of concurrent TCP connect 
+ *   attempts."  Bleah.
+ * 2007-04-25:
+ *   preserve value of WSAGetLastError() on all error returns.
+ * 2007-04-22:  (Thanks to Matthew Gregan <kinetik@flim.org>)
+ *   s/EINVAL/WSAEINVAL/ fix trivial compile failure
+ *   s/socket/WSASocket/ enable creation of sockets suitable as stdin/stdout
+ *     of a child process.
+ *   add argument make_overlapped
+ */
+
+#include <string.h>
+
+#ifdef WIN32
+# include <winsock2.h>
+# include <ws2tcpip.h>
+# include <windows.h>
+# include <io.h>
+#else
+# include <sys/types.h>
+# include <sys/socket.h>
+#endif
+
+#ifdef WIN32
+
+/* dumb_socketpair:
+ *   If make_overlapped is nonzero, both sockets created will be usable for
+ *   "overlapped" operations via WSASend etc.  If make_overlapped is zero,
+ *   socks[0] (only) will be usable with regular ReadFile etc., and thus 
+ *   suitable for use as stdin or stdout of a child process.  Note that the
+ *   sockets must be closed with closesocket() regardless.
+ */
+
+int dumb_socketpair(SOCKET socks[2], int make_overlapped)
+{
+    union {
+       struct sockaddr_in inaddr;
+       struct sockaddr addr;
+    } a;
+    SOCKET listener;
+    int e;
+    socklen_t addrlen = sizeof(a.inaddr);
+    DWORD flags = (make_overlapped ? WSA_FLAG_OVERLAPPED : 0);
+    int reuse = 1;
+
+    if (socks == 0) {
+      WSASetLastError(WSAEINVAL);
+      return SOCKET_ERROR;
+    }
+
+    listener = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (listener == INVALID_SOCKET) 
+        return SOCKET_ERROR;
+
+    memset(&a, 0, sizeof(a));
+    a.inaddr.sin_family = AF_INET;
+    a.inaddr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    a.inaddr.sin_port = 0; 
+
+    socks[0] = socks[1] = INVALID_SOCKET;
+    do {
+        if (setsockopt(listener, SOL_SOCKET, SO_REUSEADDR, 
+               (char*) &reuse, (socklen_t) sizeof(reuse)) == -1)
+            break;
+        if  (bind(listener, &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR)
+            break;
+        if  (getsockname(listener, &a.addr, &addrlen) == SOCKET_ERROR)
+            break;
+        if (listen(listener, 1) == SOCKET_ERROR)
+            break;
+        socks[0] = WSASocket(AF_INET, SOCK_STREAM, 0, NULL, 0, flags);
+        if (socks[0] == INVALID_SOCKET)
+            break;
+        if (connect(socks[0], &a.addr, sizeof(a.inaddr)) == SOCKET_ERROR)
+            break;
+        socks[1] = accept(listener, NULL, NULL);
+        if (socks[1] == INVALID_SOCKET)
+            break;
+
+        closesocket(listener);
+        return 0;
+
+    } while (0);
+
+    e = WSAGetLastError();
+    closesocket(listener);
+    closesocket(socks[0]);
+    closesocket(socks[1]);
+    WSASetLastError(e);
+    return SOCKET_ERROR;
+}
+#else
+int dumb_socketpair(int socks[2], int dummy)
+{
+    (void) dummy;
+    return socketpair(AF_LOCAL, SOCK_STREAM, 0, socks);
+}
+#endif


### PR DESCRIPTION
- run an internal thread to process event loop
- lower requirement for glibc to run on older Linux distributions
- ropen returns mode of operation and rclose does nothing now
